### PR TITLE
Added two regex to builtin.yaml

### DIFF
--- a/builtin.yaml
+++ b/builtin.yaml
@@ -21,3 +21,7 @@ number: (\d+(?:\.\d+)?) # Match numbers
 string: ("(?:[^"\\]|\\.)*") # Match double-quoted strings
 
 comment: (#[^\n]*) # Match single-line comments
+
+multi-line comment: ('''(.*?)'''|"""(.*?)""") # Match multi-line comments
+
+name: ([a-zA-Z_][a-zA-Z0-9_]*) # Match variable/function/class names


### PR DESCRIPTION
Resolves #8 by adding meaningful regular expressions in _builtin.yaml_.

1. The first expression is to match multi-line comments in Python.
2. The second expression is to match names of variables, classes, functions etc. 

Please let me know if any fixes are required or if you have any other questions.