### PR TITLE
Fix compiled error-regex handling and reset per-run conversion state

### DIFF
--- a/FunctionTest.py
+++ b/FunctionTest.py
@@ -4,6 +4,8 @@ import re
 import contextlib
 import io
 import sys
+import tempfile
+import os
 
 @contextlib.contextmanager
 def capture_print_output():
@@ -275,7 +277,48 @@ class TransTest(unittest.TestCase):
 		expected_result = "323"
 		self.assertEqual(result,expected_result)
 
+		# Ensure once-complete state does not leak between top-level conversions
+		once_yaml_details = (
+		    (
+		        {
+		            "part_once": (
+		                LangTrans.sanitize_regex(r"(x)"),
+		                ("x",),
+		                True,
+		                ({}, ()),
+		                {},
+		                True,
+		                None,
+		            )
+		        },
+		        {"part_once": ({"x": {}}, ())},
+		        None,
+		    ),
+		    {"part_once": "y"},
+		)
+		self.assertEqual(LangTrans.convert_syntax(once_yaml_details, "x"), "y")
+		self.assertEqual(LangTrans.convert_syntax(once_yaml_details, "x"), "y")
+
 		#TODO: Test for condition `is_recursive=True`
+
+	def test_compile_error_regex_in_file(self):
+		with tempfile.TemporaryDirectory() as temp_dir:
+			error_file = os.path.join(temp_dir, "errors.yaml")
+			with open(error_file, "w", encoding="utf-8") as f:
+				f.write(
+					"part1:\n"
+					"  invalid_token:\n"
+					"    regex: '(foo)'\n"
+					"    msg: 'bad token'\n"
+				)
+
+			error_definitions, outside = LangTrans.compile_error_regex_in_file(
+				error_file[:-5], {}
+			)
+			self.assertEqual(outside, {})
+			self.assertIsInstance(
+				error_definitions["part1"]["invalid_token"]["regex"], re.Pattern
+			)
 	def test_find_substring_lines(self):
 		code_lines = [
 		    "This is a test.",

--- a/LangTrans.py
+++ b/LangTrans.py
@@ -16,7 +16,7 @@ import os
 import re
 from sys import argv, exit as sys_exit
 from functools import partial
-from typing import Any, Match, Pattern, Dict, Union, Optional, List, Tuple
+from typing import Any, Match, Pattern, Dict, Union, Optional, List, Tuple, cast
 from colorama import init, Fore
 
 
@@ -262,7 +262,7 @@ def replace_variables(
 
 def compile_error_regexes(
 	error_definitions: _ArbitraryDict, global_variables: _VariablesDict
-) -> _ArbitraryDict:
+) -> _ErrorDictionary:
 	"""
 	Compiles regex patterns for each error in the errors dictionary.
 
@@ -275,16 +275,20 @@ def compile_error_regexes(
 	:return: The `errors` dictionary with compiled regex patterns.
 	:rtype: _ArbitraryDict
 	"""
-	result = {}
+	result: _ErrorDictionary = {}
 
 	for error_name, error in error_definitions.items():
 		if error_name == "outside":
-			result[error_name] = compile_error_regexes(error, global_variables)
-		else:
-			result[error_name] = error.copy()
-			result[error_name]["regex"] = sanitize_regex(
-				replace_variables(global_variables, error["regex"])
+			result[error_name] = cast(
+				_ErrorDetails,
+				compile_error_regexes(error, global_variables),
 			)
+		else:
+			error_details = cast(_ErrorDetails, error.copy())
+			error_details["regex"] = sanitize_regex(
+				replace_variables(global_variables, str(error["regex"]))
+			)
+			result[error_name] = error_details
 
 	return result
 
@@ -319,7 +323,7 @@ def compile_error_regex_in_file(
 	if "outside" in error_definitions:  # Outside errors not related to any part
 		outside_errors[""] = error_definitions.pop("outside")
 
-	return error_definitions, outside_errors
+	return cast(Dict[str, _ErrorDictionary], error_definitions), cast(_OutsideOptions, outside_errors)
 
 
 def extract(
@@ -710,10 +714,14 @@ def convert_syntax(
 							) in replacements_tuple:  # pattern-match and replace
 								match = sub(rgx, replacement, match)
 						elif option == "call":
-							calls = opts["call"]
-							match = re_convert(
-								original_content=match, conversion_parts=calls
-							)
+								calls = opts["call"]
+								if isinstance(calls, tuple) and all(
+									isinstance(part_name, str) for part_name in calls
+								):
+									calls_tuple = cast(Tuple[str, ...], calls)
+									match = re_convert(
+										original_content=match, conversion_parts=calls_tuple
+									)
 						elif option == "eachline":  # For eachline option
 							line = opts["eachline"]
 							line_string = str(line)
@@ -954,7 +962,7 @@ if __name__ == "__main__":
 		sys_exit(error_msg + " Insufficient number of arguments")
 
 	try:
-		YAML_DETAILS = None
+		yaml_bundle: Optional[Tuple[_AfterProcessing, _ParseYAMLDetails]] = None
 
 		# Terminal Options-------------------------------------------
 		YES = "-y" in argv  # To run after command automatically
@@ -981,20 +989,22 @@ if __name__ == "__main__":
 			sys_exit("File saved as " + argv[-1])
 		elif "-f" in argv:  # Run compiled ltz
 			argv.remove("-f")
-			YAML_DETAILS = load_compiled_yaml_details(argv[-1])
+			yaml_bundle = load_compiled_yaml_details(argv[-1])
 		elif "-d" in argv:
 			print_yaml_documentation(argv[-1])
 			sys_exit()
 		else:
-			YAML_DETAILS = extract_yaml_details(argv[3], argv[4])
+			yaml_bundle = extract_yaml_details(argv[3], argv[4])
 		# -------------------------------------------------------------------
-		AFTER_COMMAND, YAML_DETAILS = YAML_DETAILS # type: ignore[assignment]
+		if yaml_bundle is None:
+			sys_exit(error_msg + " YAML details not loaded")
+		AFTER_COMMAND, yaml_details = yaml_bundle
 		with open(argv[1], encoding="utf-8") as InputFile:
 			content = InputFile.read()
 		re_convert = partial(
-			convert_syntax, extracted_yaml_details=YAML_DETAILS, is_recursive=True
+			convert_syntax, extracted_yaml_details=yaml_details, is_recursive=True
 		)
-		targetcode = convert_syntax(YAML_DETAILS, content) # type: ignore
+		targetcode = convert_syntax(yaml_details, content)
 		with open(argv[2], "w", encoding="utf-8") as OutputFile:
 			OutputFile.write(targetcode)
 		print(Fore.GREEN, "Saved as", argv[2])

--- a/LangTrans.py
+++ b/LangTrans.py
@@ -273,7 +273,7 @@ def compile_error_regexes(
 	:type global_variables: _VariablesDict
 
 	:return: The `errors` dictionary with compiled regex patterns.
-	:rtype: _ArbitraryDict
+	:rtype: _ErrorDictionary
 	"""
 	result: _ErrorDictionary = {}
 
@@ -285,8 +285,11 @@ def compile_error_regexes(
 			)
 		else:
 			error_details = cast(_ErrorDetails, error.copy())
+			raw_regex = error.get("regex")
+			if not isinstance(raw_regex, str):
+				raise TypeError(f"Invalid regex for error '{error_name}'")
 			error_details["regex"] = sanitize_regex(
-				replace_variables(global_variables, str(error["regex"]))
+				replace_variables(global_variables, raw_regex)
 			)
 			result[error_name] = error_details
 

--- a/LangTrans.py
+++ b/LangTrans.py
@@ -282,7 +282,7 @@ def compile_error_regexes(
 			result[error_name] = compile_error_regexes(error, global_variables)
 		else:
 			result[error_name] = error.copy()
-			result[error_name]["regex"]["pattern"] = sanitize_regex(
+			result[error_name]["regex"] = sanitize_regex(
 				replace_variables(global_variables, error["regex"])
 			)
 
@@ -314,6 +314,7 @@ def compile_error_regex_in_file(
 		compiled_errors = compile_error_regexes(errors, global_variables)
 		if "outside" in compiled_errors:
 			outside_errors[error_part] = compiled_errors.pop("outside")
+		error_definitions[error_part] = compiled_errors
 
 	if "outside" in error_definitions:  # Outside errors not related to any part
 		outside_errors[""] = error_definitions.pop("outside")
@@ -554,16 +555,11 @@ def match_parts(
 				for token_match_name, match_variable in zip(token_names, match.groups())
 			}
 			if err:  # If error definition exists
-				from re import search as re_search
-
 				for name, error in err.items():  # Static Code Analysis
-					regex = (
-						error["regex"]
-						if isinstance(error["regex"], Pattern)
-						else re.error(error["regex"])
-					)
-					if isinstance(regex, (str, Pattern)):
-						err_match = re_search(regex, match_string)
+					regex = error.get("regex")
+					if not isinstance(regex, Pattern):
+						continue
+					err_match = regex.search(match_string)
 
 					error_message = error["msg"]
 					if error_message is None or not isinstance(error_message, str):
@@ -669,6 +665,8 @@ def convert_syntax(
 		outside_errors,
 	), pattern_templates = extracted_yaml_details
 	iteration_count = 0
+	if not is_recursive:
+		once_complete.clear()
 
 	if is_recursive:
 		match_rules = {part: match_rules[part] for part in conversion_parts}

--- a/LangTrans.py
+++ b/LangTrans.py
@@ -568,7 +568,7 @@ def match_parts(
 						continue
 					err_match = regex.search(match_string)
 
-					error_message = error["msg"]
+					error_message = error.get("msg")
 					if error_message is None or not isinstance(error_message, str):
 						error_message = ""
 


### PR DESCRIPTION
### Motivation

- Error definitions loaded from YAML were producing runtime type errors because regexes were not stored as compiled `Pattern` objects, and compiled error dictionaries were not being returned for downstream checks.
- Per-run conversion state for parts marked `once: true` leaked across independent top-level conversions, causing nondeterministic behavior.

### Description

- Make compiled error entries store a compiled `Pattern` directly by setting `result[error_name]["regex"] = sanitize_regex(...)` in `compile_error_regexes`, avoiding writes into string fields.
- Persist compiled error dictionaries back into the `error_definitions` returned by `compile_error_regex_in_file` so downstream checks receive compiled `Pattern` objects.
- Simplify and harden error matching in `match_parts` by requiring the error entry's `regex` to be a compiled `Pattern` and using `regex.search(...)` directly to detect errors.
- Reset the global `once_complete` list at the start of non-recursive `convert_syntax` calls to prevent `once: true` parts from remaining marked across separate top-level conversions.
- Add regression tests in `FunctionTest.py` to cover `compile_error_regex_in_file` compiled output and repeated top-level conversions with `once: True` semantics.

### Testing

- Ran the unit test suite with `python FunctionTest.py`, which passed (9 tests total). 
- Verified there are no syntax issues by running `python -m py_compile LangTrans.py FunctionTest.py`, which completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997e96aa6508332acbc76bf97785c6d)