### PR TITLE
Add pip install command in Quick Start section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Use the following command to clone the repository:
 ```bash
 git clone https://github.com/LangTrans/LangTrans.git
 cd LangTrans
+pip install -r requirements.txt
 ```
 
 After cloning, navigate into the LangTrans directory.


### PR DESCRIPTION
The requirements.txt file exists but the Quick start section in the README doesn't mention running pip -r requirements.txt after cloning. As a beginner i myself faced this issue while setting up the repo so i think adding this step would be really helpful for other new users.